### PR TITLE
Deprecate this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# A light weight  runtime for ReScript.
+# ⛔️ DEPRECATED Standalone ReScript runtime package (@rescript/std)
 
-The motiviation of this repo is that when ReScript users want to share their library with JS users, the JS users don't need have ReScript toolchain installed, this makes sharing code with JS users easier (more details on that topic can be found in our [External Stdlib Docs](https://rescript-lang.org/docs/manual/latest/build-external-stdlib)).
+**This repo is obsolete. The npm package @rescript/std is now built and published automatically as part of the CI process for the [ReScript compiler repo](https://github.com/rescript-lang/rescript-compiler).**
+
+The motivation for this repo is that when ReScript users want to share their library with JS users, the JS users don't need have ReScript toolchain installed, this makes sharing code with JS users easier (more details on that topic can be found in our [External Stdlib Docs](https://rescript-lang.org/docs/manual/latest/build-external-stdlib)).
 
 It shares the same version schema with ReScript compiler.
 


### PR DESCRIPTION
This repo is obsolete. The npm package @rescript/std is now built and published automatically as part of the CI process for the [ReScript compiler repo](https://github.com/rescript-lang/rescript-compiler).